### PR TITLE
Now run-tests catches SERIOUS-CONDITION instead of ERROR and prevents…

### DIFF
--- a/changelog.lisp
+++ b/changelog.lisp
@@ -7,7 +7,12 @@
 
 (defchangelog (:ignore-words ("CLISP"
                               "CFFI"
+                              "ERROR"
+                              "SERIOUS-CONDITION"
+                              "ECL"
                               "FFI"))
+  (2.3.0 2024-05-13 "
+* Now run-tests catches SERIOUS-CONDITION instead of ERROR and prevents handing of tests in the interactive prompt and timeouts on ECL.")
   (2.2.0 2024-01-30 "
 * Shell, used to run all commands was changed from bash to `lispsh -eo pipefail {0}`. This fixes runner for Windows.
 * Documentation builder workflow switched from `actions/checkout@v3` to `v4` version.")

--- a/run-tests.ros
+++ b/run-tests.ros
@@ -79,9 +79,10 @@ exec ros -Q -- $0 "$@"
 
     (unwind-protect
          (handler-bind
-             ((error (lambda (condition)
-                       (trivial-backtrace:print-backtrace condition)
-                       (uiop:quit 3))))
+             ((serious-condition
+                (lambda (condition)
+                  (trivial-backtrace:print-backtrace condition)
+                  (uiop:quit 3))))
            (when (or (null system)
                      (string= system ""))
              (format *error-output*


### PR DESCRIPTION
… handing of tests in the interactive prompt and timeouts on ECL.